### PR TITLE
Add Error for incomplete DB / install

### DIFF
--- a/src/ui/widget_main.py
+++ b/src/ui/widget_main.py
@@ -61,7 +61,11 @@ class patcher_widget(QWidget):
         self.setFixedSize(self.size())
 
         self.pipe_output()
-        self.update_patch_status()
+
+        try:
+            self.update_patch_status()
+        except util.GameDatabaseNotFoundException:
+            sys.exit()
 
         self.raise_()
     

--- a/src/util.py
+++ b/src/util.py
@@ -108,10 +108,10 @@ class Connection:
             self.conn.close()
 
 class MDBConnection(Connection):
-    DB_PATH = None
+    DB_PATH = MDB_PATH
 
 class MetaConnection(Connection):
-    DB_PATH = None
+    DB_PATH = META_PATH
 
 class NotEnoughSpaceException(Exception):
     pass

--- a/src/util.py
+++ b/src/util.py
@@ -91,26 +91,39 @@ TABLE_BACKUP_PREFIX = TABLE_PREFIX + "_bak_"
 
 DLL_BACKUP_SUFFIX = ".bak"
 
-class Connection():
+class Connection:
     DB_PATH = None
 
     def __init__(self):
-        self.conn = sqlite3.connect(self.DB_PATH)
+        if not self.DB_PATH or not os.path.exists(self.DB_PATH):
+            noGameInstallFoundException()
+            raise Exception("No complete install could be found")
+        else:
+            self.conn = sqlite3.connect(self.DB_PATH)
+
     def __enter__(self):
-        return self.conn, self.conn.cursor()
+            return self.conn, self.conn.cursor()
+
     def __exit__(self, type, value, traceback):
-        self.conn.close()
+            self.conn.close()
 
 class MDBConnection(Connection):
-    DB_PATH = MDB_PATH
+    DB_PATH = None
 
 class MetaConnection(Connection):
-    DB_PATH = META_PATH
-
+    DB_PATH = None
 
 class NotEnoughSpaceException(Exception):
     pass
 
+def noGameInstallFoundException():
+    msg = QMessageBox()
+    msg.setIcon(QMessageBox.Critical)
+    msg.setText("We couldn't find a complete install of the game.\n\nPlease make sure that you have finished the tutorial and the initial in-game download before running Carotene.\n\nIf you are still encoutering this issue please join our discord for direct help.")
+    msg.setWindowTitle("No Install Found")
+    msg.setStandardButtons(QMessageBox.Ok)
+    msg.button(QMessageBox.Ok).setText("Ok")
+    msg.exec_()
 
 def load_json(path):
     if os.path.exists(path):

--- a/src/util.py
+++ b/src/util.py
@@ -96,8 +96,8 @@ class Connection:
 
     def __init__(self):
         if not self.DB_PATH or not os.path.exists(self.DB_PATH):
-            noGameInstallFoundException()
-            raise Exception("No complete install could be found")
+            display_critical_message("No Database Found", "We couldn't find the game's database file.\n\nPlease make sure that you have finished the tutorial and the initial in-game download before running Carotene.\n\nIf you are still encoutering this issue please join our Discord server for direct help.")
+            raise GameDatabaseNotFoundException(f"Game database {self.DB_PATH} not found.")
         else:
             self.conn = sqlite3.connect(self.DB_PATH)
 
@@ -113,14 +113,17 @@ class MDBConnection(Connection):
 class MetaConnection(Connection):
     DB_PATH = META_PATH
 
+class GameDatabaseNotFoundException(Exception):
+    pass
+
 class NotEnoughSpaceException(Exception):
     pass
 
-def noGameInstallFoundException():
+def display_critical_message(title, text):
     msg = QMessageBox()
     msg.setIcon(QMessageBox.Critical)
-    msg.setText("We couldn't find a complete install of the game.\n\nPlease make sure that you have finished the tutorial and the initial in-game download before running Carotene.\n\nIf you are still encoutering this issue please join our discord for direct help.")
-    msg.setWindowTitle("No Install Found")
+    msg.setText(text)
+    msg.setWindowTitle(title)
     msg.setStandardButtons(QMessageBox.Ok)
     msg.button(QMessageBox.Ok).setText("Ok")
     msg.exec_()


### PR DESCRIPTION
closes #32

Returns an error message and stacktrace if the sqlite connection string is None or not an existing file

![image](https://github.com/KevinVG207/Uma-Carotene-English-Patch/assets/38663241/90247bf8-06d6-4714-b5ab-78295bc76274)

This still retains the original error message / unhandeled Exception afterwards, since i didnt want to change every DB call atm into a Try Catch, and in the extreme cases someone still runs into the issue after a complete install.