### PR TITLE
Add check for dlls

### DIFF
--- a/src/ui/widget_main.py
+++ b/src/ui/widget_main.py
@@ -66,6 +66,11 @@ class patcher_widget(QWidget):
 
         self.pipe_output()
 
+        # check if dlls exist in current directory
+        if dll_exists_in_folder():
+            display_critical_message("Cannot execute in current Directory", "Please make sure to not launch the Patcher inside the umamusume install directory!\n\nYou can execute it from anywhere but the umamusume directory")
+            sys.exit()
+
         try:
             self.update_patch_status()
         except util.GameDatabaseNotFoundException:

--- a/src/util.py
+++ b/src/util.py
@@ -91,6 +91,8 @@ TABLE_BACKUP_PREFIX = TABLE_PREFIX + "_bak_"
 
 DLL_BACKUP_SUFFIX = ".bak"
 
+UNWANTED_DLLS = ['version.dll', 'umpdc.dll', 'xinput1_3.dll']
+
 class Connection:
     DB_PATH = None
 
@@ -118,6 +120,9 @@ class GameDatabaseNotFoundException(Exception):
 
 class NotEnoughSpaceException(Exception):
     pass
+
+def dll_exists_in_current_folder():
+    return any(os.path.exists(dll) for dll in UNWANTED_DLLS)
 
 def display_critical_message(title, text):
     msg = QMessageBox()


### PR DESCRIPTION
Add check for game dlls in current working directory, if they are found exit gracefully with an error message for the user.

closes #36 

Cannot stop the .exe from loading the dlls for whatever reason i tried pretty much everything i found online excluding the dll form binaries or loading :(